### PR TITLE
Do not throw when luac returns an error code.

### DIFF
--- a/autoload/xolox/misc/os.vim
+++ b/autoload/xolox/misc/os.vim
@@ -19,11 +19,7 @@ function! xolox#misc#os#exec(cmdline, ...)
     return call('xolox#shell#execute', [a:cmdline, 1] + a:000)
   catch /^Vim\%((\a\+)\)\=:E117/
     " Fall back to system() when we get an "unknown function" error.
-    let output = call('system', [a:cmdline] + a:000)
-    if v:shell_error
-      throw printf("os.vim %s: Command %s failed: %s", g:xolox#misc#os#version, a:cmdline, xolox#misc#str#trim(output))
-    endif
-    return split(output, "\n")
+    return split(call('system', [a:cmdline] + a:000), "\n")
   endtry
 endfunction
 


### PR DESCRIPTION
In luac 5.1, code errors cause an error code to be returned. So, "syntax error" error codes and "undefined global variable" error codes need to be allowed through. I wasn't able to find a list of luac error codes; so, I chose to remove the "if v:shell_error" guard completely.

This fixes Issue #3
