### PR TITLE
proper handling of argument in vims embedded lua

### DIFF
--- a/misc/lua-ftplugin/omnicomplete.lua
+++ b/misc/lua-ftplugin/omnicomplete.lua
@@ -74,7 +74,7 @@ end
 
 -- Load installed modules.
 -- XXX What if module loading has side effects? It shouldn't, but still...
-for _, modulename in ipairs(arg) do
+for _, modulename in (type(arg) == 'table' and ipairs(arg) or arg()) do
   local status, module = pcall(require, modulename)
   if status and module and not _G[modulename] then
     _G[modulename] = module


### PR DESCRIPTION
Vi IMproved 7.3 1-918 passes argument as user data. Update for omnicomplete.
