### PR TITLE
Allow blacklisting of require()'d modules while omni completion loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ If you want to use the omni completion despite the warnings above, execute the f
 
 Now when you type Control-X Control-O Vim will hang for a moment, after which you should be presented with an enormous list of completion candidates :-)
 
+### The `lua_omni_module_blacklist` option
+
+Setting this option to a list of Lua module names causes them not to be loaded, i.e., blacklisted, when aggregating candidates for omni completion. 
+Loading particular Lua modules having side effects can be avoided with this option. In addition, deliberately excluding further Lua modules results in a faster omni completion candidates loading.
+
+The list of Lua modules to be inspected for omni completion candidates is regex-filtered by this option's entries enclosed in ``^`` and ``$``. For example, defining
+
+    :let g:lua_omni_module_blacklist = ['pl\.strict', 'lgi\..*']
+
+prevents the module ``pl.strict`` and all modules with the prefix ``lgi.`` from being loaded.
+
+The list of Lua modules loaded while gathering omni completion candidates is available via ``:messages`` if the ``verbose`` option is set to a value greater than 0.
+
 ### The `lua_define_completefunc` option
 
 By default the Lua file type plug-in sets the ['completefunc'] [] option so that Vim can complete Lua keywords, global variables and library members using Control-X Control-U. If you don't want the 'completefunc' option to be changed by the plug-in, you can set this option to zero (false) in your [vimrc script] [vimrc]:

--- a/autoload/xolox/lua.vim
+++ b/autoload/xolox/lua.vim
@@ -467,6 +467,17 @@ function! xolox#lua#tweakoptions() " {{{1
 endfunction
 
 function! xolox#lua#dofile(pathname, arguments) " {{{1
+  if exists("g:lua_omni_module_blacklist") && type(g:lua_omni_module_blacklist) == 3
+    let l:blacklist = join(map(copy(g:lua_omni_module_blacklist), '"v:val!~\"^".v:val."$\""'),'&&')
+    call filter(a:arguments, l:blacklist)
+    call xolox#misc#msg#debug("lua.vim %s: modules to load are filtered by %s",
+          \ g:xolox#lua#version,
+          \ join(g:lua_omni_module_blacklist, " "))
+  endif
+  call xolox#misc#msg#debug("lua.vim %s: running luafile %s %s",
+        \ g:xolox#lua#version,
+        \ fnameescape(a:pathname),
+        \ join(a:arguments, " "))
   if has('lua')
     " Use the Lua Interface for Vim.
     redir => output

--- a/doc/ft_lua.txt
+++ b/doc/ft_lua.txt
@@ -17,9 +17,10 @@ Contents ~
   9. The |lua_complete_library| option
   10. The |lua_complete_dynamic| option
   11. The |lua_complete_omni| option
-  12. The |lua_define_completefunc| option
-  13. The |lua_define_omnifunc| option
-  14. The |lua_define_completion_mappings| option
+  12. The |lua_omni_module_blacklist| option
+  13. The |lua_define_completefunc| option
+  14. The |lua_define_omnifunc| option
+  15. The |lua_define_completion_mappings| option
  4. Contact                                                    |ft_lua-contact|
  5. License                                                    |ft_lua-license|
  6. References                                              |ft_lua-references|
@@ -199,6 +200,27 @@ following command:
 <
 Now when you type Control-X Control-O Vim will hang for a moment, after which
 you should be presented with an enormous list of completion candidates :-)
+
+-------------------------------------------------------------------------------
+The *lua_omni_module_blacklist* option
+
+Setting this option to a list of Lua module names causes them not to be loaded,
+i.e., blacklisted, when aggregating candidates for omni completion.
+Loading particular Lua modules having side effects can be avoided with this
+option. In addition, deliberately excluding further Lua modules results in a
+faster omni completion candidates loading.
+
+The list of Lua modules to be inspected for omni completion candidates is
+regex-filtered by this option's entries enclosed in '^' and '$'. For example,
+defining
+>
+  :let g:lua_omni_module_blacklist = ['pl\.strict', 'lgi\..*']
+<
+prevents the module 'pl.strict' and all modules with the prefix 'lgi.' from
+being loaded.
+
+The list of Lua modules loaded while gathering omni completion candidates is
+available via |:messages| if the |verbose| option is set to a value > 0.
 
 -------------------------------------------------------------------------------
 The *lua_define_completefunc* option


### PR DESCRIPTION
In reference to #12, allow particular modules causing side effects to be excluded from omni completion candidates loading via regex-based blacklisting.
