### PR TITLE
Update docs to refer to correct option lua_omni_blacklist and provide option to inspect omni completion module loading list

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Now when you type Control-X Control-O Vim will hang for a moment, after which yo
 
 ### The `lua_omni_blacklist` option
 
-If you like the omni completion mode but certain modules are giving you trouble (for example crashing Vim) you can exclude such modules from being loaded by the omni completion. You can do so by setting `lua_omni_module_blacklist` to a list of strings containing Vim regular expression patterns. The patterns are combined as follows:
+If you like the omni completion mode but certain modules are giving you trouble (for example crashing Vim) you can exclude such modules from being loaded by the omni completion. You can do so by setting `lua_omni_blacklist` to a list of strings containing Vim regular expression patterns. The patterns are combined as follows:
 
     " Here's the black list:
     let g:lua_omni_blacklist = ['pl\.strict', 'lgi\..']

--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ If you like the omni completion mode but certain modules are giving you trouble 
 
 The example above prevents the module `pl.strict` and all modules with the prefix `lgi.` from being loaded.
 
+### The `lua_safe_omni_modules` option
+
+To track down modules that cause side effects while loading, setting
+
+    :let g:lua_safe_omni_modules = 1
+
+restricts the modules to be loaded to the standard Lua modules - which should be safe to load - and provides a list of modules that would have been loaded if this option was not set via the `:messages` command. With this list, the `lua_omni_blacklist` can be iteratively refined to exclude offending modules from omni completion module loading.
+Note that the ['verbose'] [] option has to be >= 1 for the list to be recorded.
+
 ### The `lua_define_completefunc` option
 
 By default the Lua file type plug-in sets the ['completefunc'] [] option so that Vim can complete Lua keywords, global variables and library members using Control-X Control-U. If you don't want the 'completefunc' option to be changed by the plug-in, you can set this option to zero (false) in your [vimrc script] [vimrc]:
@@ -159,6 +168,7 @@ This software is licensed under the [MIT license](http://en.wikipedia.org/wiki/M
 © 2014 Peter Odding &lt;<peter@peterodding.com>&gt;.
 
 
+['verbose']: http://vimdoc.sourceforge.net/htmldoc/options.html#'verbose'
 ['completefunc']: http://vimdoc.sourceforge.net/htmldoc/options.html#'completefunc'
 ['omnifunc']: http://vimdoc.sourceforge.net/htmldoc/options.html#'omnifunc'
 [cfu]: http://vimdoc.sourceforge.net/htmldoc/options.html#%27completefunc%27

--- a/autoload/xolox/lua.vim
+++ b/autoload/xolox/lua.vim
@@ -397,6 +397,11 @@ function! xolox#lua#getomnimodules() " {{{1
   call filter(modules, 'v:val !~ pattern')
   let msg = "lua.vim %s: Collected %i module names for omni completion in %s."
   call xolox#misc#timer#stop(msg, g:xolox#lua#version, len(modules), starttime)
+  if xolox#misc#option#get('lua_safe_omni_modules', 0) == 1
+    call xolox#misc#msg#debug("lua.vim: loading Lua standard modules only as g:lua_safe_omni_modules == 1")
+    call xolox#misc#msg#debug("lua.vim: would have loaded: %s", join(modules, ' '))
+    return ['coroutine', 'debug', 'io', 'math', 'os', 'package', 'string', 'table']
+  endif
   return modules
 endfunction
 

--- a/doc/ft_lua.txt
+++ b/doc/ft_lua.txt
@@ -242,6 +242,22 @@ The example above prevents the module 'pl.strict' and all modules with the
 prefix 'lgi.' from being loaded.
 
 -------------------------------------------------------------------------------
+The *lua_safe_omni_modules* option
+
+This option can be used to track down modules that cause side effects while
+loading. Setting
+>
+    :let g:lua_safe_omni_modules = 1
+<
+restricts the modules to be loaded to the standard Lua modules - which should
+be safe to load - and provides a list of modules that would have been loaded
+if this option was not set via the |:messages| command.
+With this list, the |lua_omni_blacklist| can be iteratively refined to exclude
+offending modules from omni completion module loading.
+
+Note that the |verbose| option has to be >= 1 for the list to be recorded.
+
+-------------------------------------------------------------------------------
 The *lua_define_completefunc* option
 
 By default the Lua file type plug-in sets the |'completefunc'| option so that

--- a/doc/ft_lua.txt
+++ b/doc/ft_lua.txt
@@ -228,7 +228,7 @@ The *lua_omni_blacklist* option
 
 If you like the omni completion mode but certain modules are giving you trouble
 (for example crashing Vim) you can exclude such modules from being loaded by
-the omni completion. You can do so by setting 'lua_omni_module_blacklist' to a
+the omni completion. You can do so by setting 'lua_omni_blacklist' to a
 list of strings containing Vim regular expression patterns. The patterns are
 combined as follows:
 >


### PR DESCRIPTION
Replaced references to non-existent option `lua_omni_module_blacklist` by references to `lua_omni_blacklist` in the documentation.

As I found it rather cumbersome to track down modules having side effects while loading modules for omni completion, I suggest something along the line of 2c69923 which -- at least for me -- was a great help.
