### PR TITLE
Fix off-by-one error in s:getsynid

### DIFF
--- a/autoload/xolox/lua.vim
+++ b/autoload/xolox/lua.vim
@@ -250,7 +250,7 @@ function! xolox#lua#tokeniscode() " {{{1
 endfunction
 
 function! s:getsynid(transparent)
-  let id = synID(line('.'), col('.') - 1, 1)
+  let id = synID(line('.'), col('.'), 1)
   if a:transparent
     let id = synIDtrans(id)
   endif


### PR DESCRIPTION
This fixes skipping with matchit (via xolox#lua#matchit_ignore).

It was changed in 5cf57e068, but this looks like not being done
intentionally.
