### PR TITLE
Prevent automatically selecting first option on autocomplete menu popup

### DIFF
--- a/autoload/xolox/lua.vim
+++ b/autoload/xolox/lua.vim
@@ -472,7 +472,7 @@ function! xolox#lua#completedynamic(type) " {{{1
         if xolox#misc#option#get('lua_complete_omni', 0)
           return a:type . "\<C-x>\<C-o>"
         else
-          return a:type . "\<C-x>\<C-u>"
+          return a:type . "\<C-x>\<C-u>\<C-p>"
         endif
       endif
     endif


### PR DESCRIPTION
I've been experiencing a problem related with autocomplete of Lua keywords. On pressing dot, Vim automatically picks up the first choice.

For instance, if I type "table", then on typing ".", Vim automatically autocompletes with "concat" which is the first menu entry. Then I have to remove "concat" to see all the possible options.

I don't know whether other users experienced the same issue. But it seems it's a common problem related with Vim's autocomplete. See: 

https://github.com/davidhalter/jedi-vim/issues/32

The patch fixes the issue in a similar fashion as in the link pasted above. Downside is that complete menu do not marks any choice. To pick up one is necessary to press "down" and then return. 