### PR TITLE
Only define autocmds for lua files

### DIFF
--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -94,6 +94,15 @@ if has('balloon_eval')
   call add(s:undo_ftplugin, 'setlocal ballooneval< balloonexpr<')
 endif
 
+" Autocommands {{{1
+" Automatic commands to check for syntax errors and/or undefined globals
+" and change Vim's "completeopt" setting on the fly for Lua buffers.
+augroup PluginFileTypeLua
+  autocmd!
+  autocmd WinEnter <buffer> call xolox#lua#tweakoptions()
+  autocmd BufWritePost <buffer> call xolox#lua#autocheck()
+augroup END
+
 " }}}1
 
 " Let Vim know how to disable the plug-in.

--- a/plugin/lua-ftplugin.vim
+++ b/plugin/lua-ftplugin.vim
@@ -29,14 +29,6 @@ endtry
 command! -bar LuaCheckSyntax call xolox#lua#checksyntax()
 command! -bar -bang LuaCheckGlobals call xolox#lua#checkglobals(<q-bang> == '!')
 
-" Automatic commands to check for syntax errors and/or undefined globals
-" and change Vim's "completeopt" setting on the fly for Lua buffers.
-augroup PluginFileTypeLua
-  autocmd!
-  autocmd WinEnter * call xolox#lua#tweakoptions()
-  autocmd BufWritePost * call xolox#lua#autocheck()
-augroup END
-
 " Make sure the plug-in is only loaded once.
 let g:loaded_lua_ftplugin = 1
 


### PR DESCRIPTION
Fix #17.

Limit automatic commands to check for syntax errors/undefined globals
and change Vim's "completeopt" setting to lua buffers.